### PR TITLE
build(operaciones): Utiliza loadAll

### DIFF
--- a/Config/bootstrap.php
+++ b/Config/bootstrap.php
@@ -64,10 +64,7 @@ Configure::write('Dispatcher.filters', array(
     'AssetDispatcher',
     'CacheDispatcher'
 ));
-CakePlugin::load('Upload');
-CakePlugin::load('DebugKit');
-CakePlugin::load('CakePdf', array('bootstrap' => true, 'routes' => true));
-CakePlugin::load('Migrations');
+CakePlugin::loadAll(array('CakePdf' => array('bootstrap' => true, 'routes' => true)));
 /**
  * Configuration CakePdf
  */


### PR DESCRIPTION
De esta manera se evitan errores en produccion, donde no se instalan dependencias de desarrollo.
Documentacion de referencia: https://book.cakephp.org/2.0/en/plugins/how-to-use-plugins.html

Closes #7