### PR TITLE
Docker permite instalar composer desde cero

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,6 +4,8 @@ services:
   siep-mysql:
     ports:
       - "3306:3306"
+    volumes:
+      - ".:/home"
 
   siep-nginx:
     build:

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -9,7 +9,7 @@ COPY docker/php-fpm/php-ini-overrides.ini /etc/php/7.1/fpm/conf.d/99-overrides.i
 WORKDIR "/var/www/myapp"
 # Setup the Composer installer
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-    && php -r "if (hash_file('SHA384', 'composer-setup.php') === '669656bab3166a7aff8a7506b8cb2d1c292f042046c5a994c43155c0be6190fa0355160742ab2e1c88d40d5be660b410') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+    && php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
     && php composer-setup.php \
     && php -r "unlink('composer-setup.php');"
 COPY composer.json composer.lock ./


### PR DESCRIPTION
Tambien docker monta el proyecto en el contenedor mysql

lo que permite importar la base de datos mayor a 2MB 

Simplemente ingresando al contenedor y ejecutando:
siep-mysql#  mysql -u siep -p siep < archivo_para_migracion.sql