### PR TITLE
Se agregan filtros para supervision

### DIFF
--- a/Controller/VacantesController.php
+++ b/Controller/VacantesController.php
@@ -94,19 +94,27 @@ class VacantesController extends AppController
         {
             $apiParams['centro_id'] = $userCentro['id'];
         }
+
         if($this->Siep->isUsuario())
         {
-            $userNivelServicio = $userCentro['nivel_servicio'];
-
-            if ($userNivelServicio === 'Común - Inicial - Primario') {
-                $apiParams['centro_id'] = $userCentro['id'];
+            // Supervision Primaria ve Jardines y Escuelas
+            if($this->Siep->isSupervisionInicialPrimaria())
+            {
                 $apiParams['nivel_servicio'] = [
                     'Común - Inicial',
                     'Común - Primario',
                     'Común - Inicial - Primario'
                 ];
-
+            } elseif ($this->Siep->isSupervisionSecundaria())
+            {
+                // Supervision Secundaria, solo ve colegios secundarios
+                $apiParams['nivel_servicio'] = [
+                    'Común - Secundario'
+                ];
             } else {
+                // El resto de los usuarios, ven a los inscriptos de sus establecimientos, en su nivel de servicio
+                $userNivelServicio = $userCentro['nivel_servicio'];
+                $apiParams['centro_id'] = $userCentro['id'];
                 $apiParams['nivel_servicio'] = $userNivelServicio;
             }
         }

--- a/View/Helper/SiepHelper.php
+++ b/View/Helper/SiepHelper.php
@@ -20,6 +20,16 @@ class SiepHelper extends AppHelper
         return (AuthComponent::user('role') == 'admin') ? true : false;
     }
 
+    public function isSupervisionInicialPrimaria()
+    {
+        return (AuthComponent::user('puesto') == 'Supervisión Inicial/Primaria') ? true : false;
+    }
+
+    public function isSupervisionSecundaria()
+    {
+        return (AuthComponent::user('puesto') == 'Supervisión Secundaria') ? true : false;
+    }
+
     public function logQuery($modelo)
     {
         $log = $modelo->getDataSource()->getLog(false, false);


### PR DESCRIPTION
El puesto Supervision Inicial/Primaria ve Jardines y Escuelas, 
El puesto Supervision Secundaria, ve colegios secundarios.
El resto de los roles "usuario" ven a los inscriptos segun su centro y nivel de servicio asignado