### PR TITLE
Corrige visualización de tildes en EDIT de Inscripciones

### DIFF
--- a/Controller/InscripcionsController.php
+++ b/Controller/InscripcionsController.php
@@ -496,9 +496,10 @@ class InscripcionsController extends AppController {
                 $this->redirect( array( 'action' => 'index' ));
 		    }
             /* INICIO:  Definición del estado de la documentación según el nivel del centro.*/
-            $userCentroId = $this->getUserCentroId();
-            $userCentroNivel = $this->getUserCentroNivel($userCentroId);
-            switch($userCentroNivel) {
+            $CentroId = $this->Inscripcion->findById($id, 'centro_id');
+            $CentroIdString = $CentroId['Inscripcion']['centro_id'];
+            $CentroNivel = $this->getUserCentroNivel($CentroIdString);
+            switch($CentroNivel) {
                 case 'Común - Inicial':
                 case 'Común - Primario':
                     if(($this->request->data['Inscripcion']['fotocopia_dni'] ==1) && ($this->request->data['Inscripcion']['partida_nacimiento_alumno'] ==1) && ($this->request->data['Inscripcion']['certificado_vacunas'] ==1)) {
@@ -515,7 +516,7 @@ class InscripcionsController extends AppController {
                     }                        
                     break;
                 default:
-                    $estadoDocumentacion = "PENDIENTE";
+                    //$estadoDocumentacion = "PENDIENTE";
             }
             //Se genera el estado y se deja en los datos que se intentaran guardar
             $this->request->data['Inscripcion']['estado_documentacion'] = $estadoDocumentacion;
@@ -636,8 +637,17 @@ class InscripcionsController extends AppController {
 				$this->Session->setFlash('La inscripcion no fue grabada. Intente nuevamente.', 'default', array('class' => 'alert alert-danger'));
 			}
 		}
+        //Genera variables para forzar tildes en la vista.
+        $tildeDocumento = $this->Inscripcion->findById($id, 'fotocopia_dni');
+        $tildeDocumentoString = $tildeDocumento['Inscripcion']['fotocopia_dni'];
+        $tildePartida = $this->Inscripcion->findById($id, 'partida_nacimiento_alumno');
+        $tildePartidaString = $tildePartida['Inscripcion']['partida_nacimiento_alumno'];
+        $tildeVacunas = $this->Inscripcion->findById($id, 'certificado_vacunas');
+        $tildeVacunasString = $tildeVacunas['Inscripcion']['certificado_vacunas'];
+        $tildeSeptimo = $this->Inscripcion->findById($id, 'certificado_septimo');
+        $tildeSeptimoString = $tildeSeptimo['Inscripcion']['certificado_septimo'];
         // End submit de formulario
-        $this->set(compact('cursoInscripcion','alumno', 'personaId', 'estadoInscripcionAnteriorArray'));
+        $this->set(compact('cursoInscripcion','alumno', 'personaId', 'estadoInscripcionAnteriorArray', 'tildeDocumentoString', 'tildePartidaString', 'tildeVacunasString', 'tildeSeptimoString'));
     }
 
     public function delete($id = null) {
@@ -742,6 +752,5 @@ class InscripcionsController extends AppController {
             return ['error'=>$ex->getMessage()];
         }
     }
-
 }
 ?>

--- a/View/Elements/forms/form_inscripcion_edit.ctp
+++ b/View/Elements/forms/form_inscripcion_edit.ctp
@@ -167,17 +167,17 @@
       <br>
         <div class="input-group">
           <span class="input-group-addon">
-            <?php echo $this->Form->input('fotocopia_dni', array('between' => '<br>', 'class' => 'form-control', 'label' => false, 'type' => 'checkbox', 'before' => '<label class="checkbox">', 'after' => '<br><i></i><br>Fotocopia DNI</label>'));?>
+            <?php echo $this->Form->input('fotocopia_dni', array('default'=>$tildeDocumentoString, 'between' => '<br>', 'class' => 'form-control', 'label' => false, 'type' => 'checkbox', 'before' => '<label class="checkbox">', 'after' => '<br><i></i><br>Fotocopia DNI</label>'));?>
           </span>
         </div>
         <div class="input-group">
           <span class="input-group-addon">
-            <?php echo $this->Form->input('partida_nacimiento_alumno', array('between' => '<br>', 'class' => 'form-control', 'label' => false, 'type' => 'checkbox', 'before' => '<label class="checkbox">', 'after' => '<br><i></i><br>Partida de Nacimiento Alumno</label>'));?>
+            <?php echo $this->Form->input('partida_nacimiento_alumno', array('default'=>$tildePartidaString, 'between' => '<br>', 'class' => 'form-control', 'label' => false, 'type' => 'checkbox', 'before' => '<label class="checkbox">', 'after' => '<br><i></i><br>Partida de Nacimiento Alumno</label>'));?>
           </span>
         </div>
         <div class="input-group">
           <span class="input-group-addon">
-            <?php echo $this->Form->input('certificado_vacunas', array('between' => '<br>', 'class' => 'form-control', 'label' => false, 'type' => 'checkbox', 'before' => '<label class="checkbox">', 'after' => '<br><i></i><br>Certificado Vacunación</label>'));?>
+            <?php echo $this->Form->input('certificado_vacunas', array('default'=>$tildeVacunasString, 'between' => '<br>', 'class' => 'form-control', 'label' => false, 'type' => 'checkbox', 'before' => '<label class="checkbox">', 'after' => '<br><i></i><br>Certificado Vacunación</label>'));?>
           </span>
         </div>
         <!--
@@ -192,7 +192,7 @@
         ?>  
         <div class="input-group">
             <span class="input-group-addon">
-             <?php echo $this->Form->input('certificado_septimo', array('between' => '<br>', 'class' => 'form-control', 'label' => false, 'type' => 'checkbox', 'before' => '<label class="checkbox">', 'after' => '<br><i></i><br>Certificado Primario Completo</label>'));?>
+             <?php echo $this->Form->input('certificado_septimo', array('default'=>$tildeSeptimoString, 'between' => '<br>', 'class' => 'form-control', 'label' => false, 'type' => 'checkbox', 'before' => '<label class="checkbox">', 'after' => '<br><i></i><br>Certificado Primario Completo</label>'));?>
             </span>
         </div>
         <!--

--- a/View/Inscripcions/view.ctp
+++ b/View/Inscripcions/view.ctp
@@ -73,7 +73,7 @@
                                     <li><span class="label label-danger"><?php echo 'Falta Partida Alumno'; ?></span></li><?php endif; ?>
                                     <?php if(!$inscripcion['certificado_vacunas'] == 1): ?>
                                     <li><span class="label label-danger"><?php echo 'Certificado vacunación'; ?></span></li><?php endif; ?>
-                                    <?php if(($current_user['puesto'] == 'Dirección Colegio Secundario' || $current_user['puesto'] == 'Supervisión Secundaria') && (!$inscripcion['certificado_septimo'] == 1)): ?>
+                                    <?php if(($current_user['role'] == 'superadmin' || $current_user['puesto'] == 'Dirección Colegio Secundario' || $current_user['puesto'] == 'Supervisión Secundaria') && ($inscripcion['certificado_septimo'] == 0)): ?>
                                     <li><span class="label label-danger"><?php echo 'Falta Certificado Primaria'; ?></span></li><?php endif; ?>
                                   </ul>
                             </div>


### PR DESCRIPTION
## Descripción
Se visualizan los tildes que indican la documentación presentada al inscribir y se visualiza correctamente el estado de la documentación presentada.
 
## Motivación y Contexto
No se visualizaban en EDIT los tildes realizados en ADD de INSCRIPCIÓN. Tampoco se definía el estado de la documentación presentada en VIEW. 

## Tipo de cambios
- [x] Bug fix (cambio que no rompe la api existente y resuelve un issue)
- [ ] Nueva funcionalidad (cambio que no rompe la api existente y agrega funcionalidad)
- [ ] Cambio en la api (un fix o funcionalidad que modifica la api existente).