### PR TITLE
Permite visualizar inscripciones en estado de BAJA y EGRESO en ALUMNO…

### DIFF
--- a/Controller/CursosInscripcionsController.php
+++ b/Controller/CursosInscripcionsController.php
@@ -106,7 +106,7 @@ class CursosInscripcionsController extends AppController {
 			case 'admin':
 				$this->paginate['CursosInscripcion']['conditions'] = array(
 					'Inscripcion.centro_id' => $userCentroId,
-					'Inscripcion.estado_inscripcion' =>array('CONFIRMADA','NO CONFIRMADA')
+					'Inscripcion.estado_inscripcion' =>array('CONFIRMADA','NO CONFIRMADA', 'BAJA', 'EGRESO')
 				);
 				$queryExportacionExcel['centro_id'] = $userCentroId;
 				$showExportBtn++;
@@ -124,7 +124,7 @@ class CursosInscripcionsController extends AppController {
 
 					$this->paginate['CursosInscripcion']['conditions'] = array(
 						'Inscripcion.centro_id' => $nivelCentroId,
-						'Inscripcion.estado_inscripcion' =>array('CONFIRMADA','NO CONFIRMADA')
+						'Inscripcion.estado_inscripcion' =>array('CONFIRMADA','NO CONFIRMADA', 'BAJA', 'EGRESO')
 					);
 				} else
 				{
@@ -134,7 +134,7 @@ class CursosInscripcionsController extends AppController {
 					);
 					$this->paginate['CursosInscripcion']['conditions'] = array(
 						'Inscripcion.centro_id' => $nivelCentroId,
-						'Inscripcion.estado_inscripcion' =>array('CONFIRMADA','NO CONFIRMADA')
+						'Inscripcion.estado_inscripcion' =>array('CONFIRMADA','NO CONFIRMADA', 'BAJA', 'EGRESO')
 					);
 				}
 				break;


### PR DESCRIPTION
## Descripción
Corrige filtrar y visualizar INSCRIPCIONES según los estados BAJA y EGRESO en ALUMNOS NOMINALES.

## Motivación y Contexto
No permitía visualizar INSCRIPCIONES en estado de BAJA y EGRESO.

## Tipo de cambios
- [x] Bug fix (cambio que no rompe la api existente y resuelve un issue)
- [ ] Nueva funcionalidad (cambio que no rompe la api existente y agrega funcionalidad)
- [ ] Cambio en la api (un fix o funcionalidad que modifica la api existente).