### PR TITLE
Deshabilita modificar el estado en las inscripciones denominadas SINV…

### DIFF
--- a/Controller/InscripcionsController.php
+++ b/Controller/InscripcionsController.php
@@ -651,8 +651,14 @@ class InscripcionsController extends AppController {
         $cicloInscripcionIdString = $cicloInscripcionId['Inscripcion']['ciclo_id'];
         $cicloInscripcionNombre = $this->Ciclo->findById($cicloInscripcionIdString, 'nombre');
         $cicloInscripcionNombreString = $cicloInscripcionNombre['Ciclo']['nombre'];
+        /*Verifica sí se trata de una inscripción con denominación SIN VACANTE.*/
+        //Obtiene el string de la inscripción.
+        $inscripcionLegajoNroArray = $this->Inscripcion->findById($id, 'legajo_nro');
+        $inscripcionLegajoNroString = $inscripcionLegajoNroArray['Inscripcion']['legajo_nro'];
+        //Obtiene la denominación 'SINVACANTE'
+        $sinVacante = substr($inscripcionLegajoNroString, -12, 10);
         // End submit de formulario
-        $this->set(compact('cursoInscripcion','alumno', 'personaId', 'estadoInscripcionAnteriorArray', 'tildeDocumentoString', 'tildePartidaString', 'tildeVacunasString', 'tildeSeptimoString', 'cicloInscripcionIdString', 'cicloInscripcionNombreString'));
+        $this->set(compact('cursoInscripcion','alumno', 'personaId', 'estadoInscripcionAnteriorArray', 'tildeDocumentoString', 'tildePartidaString', 'tildeVacunasString', 'tildeSeptimoString', 'cicloInscripcionIdString', 'cicloInscripcionNombreString', 'sinVacante'));
     }
 
     public function delete($id = null) {

--- a/View/Elements/forms/form_inscripcion_edit.ctp
+++ b/View/Elements/forms/form_inscripcion_edit.ctp
@@ -54,7 +54,13 @@
   <div class="col-xs-6 col-sm-3">
       <?php
           $estados_inscripcion = array('CONFIRMADA'=>'CONFIRMADA','NO CONFIRMADA'=>'NO CONFIRMADA','BAJA'=>'BAJA','EGRESO'=>'EGRESO');
-           echo $this->Form->input('estado_inscripcion', array('default'=>$estadoInscripcionAnteriorArray['Inscripcion']['estado_inscripcion'],'label'=>'Estado de la inscripción*', 'empty' => 'Ingrese un estado de inscripción...', 'options'=>$estados_inscripcion, 'class' => 's2_general form-control', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'title' => 'Seleccione una opción'));
+          //Si el número de legajo tiene la denominación "SINVACANTE", deshabilita la modificación del estado de inscripción.
+          if ($sinVacante === 'SINVACANTE') {
+            echo $this->Form->input('estado_inscripcion', array('default'=>$estadoInscripcionAnteriorArray['Inscripcion']['estado_inscripcion'],'label'=>'Estado de la inscripción*', 'disabled' =>true, 'empty' => 'Ingrese un estado de inscripción...', 'options'=>$estados_inscripcion, 'class' => 's2_general form-control', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'title' => 'Seleccione una opción'));
+            echo $this->Form->input('estado_inscripcion', array('type' => 'hidden', 'default'=>$estadoInscripcionAnteriorArray['Inscripcion']['estado_inscripcion']));
+          } else {
+            echo $this->Form->input('estado_inscripcion', array('default'=>$estadoInscripcionAnteriorArray['Inscripcion']['estado_inscripcion'],'label'=>'Estado de la inscripción*', 'empty' => 'Ingrese un estado de inscripción...', 'options'=>$estados_inscripcion, 'class' => 's2_general form-control', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'title' => 'Seleccione una opción'));
+          }  
       ?>
       <?php echo $this->Form->input('usuario_id', array('type' => 'hidden')); ?>
   </div>


### PR DESCRIPTION
## Descripción
Deshabilita la opción de modificar el estado de inscripción cuando su código contiene la denominación SINVACANTE.

## Motivación y Contexto
La inscripciones que en su código contiene la denominación SINVAVANTE, SIEP les asigna el estado BAJA. En algunos casos este estado fue modificado por los usuarios.

## Tipo de cambios
- [x] Bug fix (cambio que no rompe la api existente y resuelve un issue)
- [ ] Nueva funcionalidad (cambio que no rompe la api existente y agrega funcionalidad)
- [ ] Cambio en la api (un fix o funcionalidad que modifica la api existente).