### PR TITLE
Valida DNIs extranjeros cortos

### DIFF
--- a/Model/Persona.php
+++ b/Model/Persona.php
@@ -82,7 +82,7 @@ class Persona extends AppModel {
                 'message' => 'Indicar un nº de documento.'
                 ),
                 'alphaBet' => array(
-                'rule' => '/^[ a-zA-Z 0-9]{8,}$/i',
+                'rule' => '/^[ a-zA-Z 0-9]{5,}$/i',
                 'message' => 'Sólo letras y números, mínimo ocho caracteres, sin puntos, guiones ni espacios.'
                 ),
                 'isUnique' => array(


### PR DESCRIPTION
## Descripción
Permite el ingreso de DNIs cortos y alfanuméricos de PERSONAs extranjeras.

## Motivación y Contexto
Posibilita el ingreso de números de documentos de personas extranjeras hasta no tanto obtengan su DNI.

## Tipo de cambios
- [x] Bug fix (cambio que no rompe la api existente y resuelve un issue)
- [ ] Nueva funcionalidad (cambio que no rompe la api existente y agrega funcionalidad)
- [ ] Cambio en la api (un fix o funcionalidad que modifica la api existente).