### PR TITLE
Ajusta visualizaciones de matrículas 2018 y 2019

### DIFF
--- a/View/Cursos/view.ctp
+++ b/View/Cursos/view.ctp
@@ -16,15 +16,18 @@
 							<?php echo ($curso['Curso']['turno']); ?></p>
 						<b><?php echo __('Tipo: '); ?></b>
 							<?php echo ($curso['Curso']['tipo']); ?></p>	
-						<b><?php echo __('Aula: '); ?></b>
-							<?php echo ($curso['Curso']['aula_nro']); ?></p>
+						<!--<b><?php echo __('Aula: '); ?></b>
+							<?php echo ($curso['Curso']['aula_nro']); ?></p>-->
 			            <?php if($curso['Curso']['division']): ?>
 			            <b><?php echo __('Plazas: '); ?></b> 
-			            	<span class="badge"><?php echo ($cursoPlazasString); ?></span></button></b>
-						<b><?php echo __(' | Matriculados: '); ?></b>
-							<span class="badge"><?php echo ($cursoMatriculaString); ?></span></button></b><br/><br/>
-						<button class="btn btn-primary" type="button">Vacantes: 
-							<span class="badge"><?php echo ($vacantes); ?></span></button>
+			            	<span class="badge"><?php echo ($cursoPlazasString); ?></span></button></b><br/><br/>
+						<strong>CICLO 2018</strong><br/>
+						<b><?php echo __('| Matriculados: '); ?></b>
+							<span class="badge"><?php echo ($cursoMatriculaString); ?></span></button></b><br/>
+						<b><?php echo __('| Matriculados: '); ?></b>
+							<span class="badge"><?php echo ($vacantes); ?></span></button></b>	
+						<!--<button class="btn btn-primary" type="button">Vacantes: 
+							<span class="badge"><?php echo ($vacantes); ?></span></button>-->
 						<?php endif; ?>	
                     </div>
                     <!--<div class="col-md-4 col-sm-6 col-xs-8">	

--- a/View/Elements/menues/menu-aip.ctp
+++ b/View/Elements/menues/menu-aip.ctp
@@ -70,13 +70,11 @@
           <ul class="dropdown-menu">
             <li><?php echo $this->Html->link(__('Instituciones'),'/centros'); ?></li>
             <li><?php echo $this->Html->link(__('Alumnos por Sección [nominal]'), '/cursos_inscripcions');?></li>
-            <li><?php echo $this->Html->link(__('Alumnos por Sección [cuantitativo]'), '/matriculas');?></li>
-            <li><?php echo $this->Html->link(__('Ingresantes 2019'), '/ingresantes');?></li>
-            <li><?php echo $this->Html->link(__('Inscriptos 2019'), '/vacantes');?></li>
+            <!--<li><?php echo $this->Html->link(__('Alumnos por Unidad Curricular'), '/inscripcions_materias');?></li>-->
+            <li><?php echo $this->Html->link(__('Inscripciones 2018 [cuantitativo]'), '/matriculas');?></li>
+            <li><?php echo $this->Html->link(__('Ingresantes 2019 [cuantitativo]'), '/ingresantes');?></li>
+            <li><?php echo $this->Html->link(__('Inscripciones 2019 [cuantitativo]'), '/vacantes');?></li>
             <!--<li><?php echo $this->Html->link(__('Gráficos Estadísticos'), '/graficos'); ?></li>-->
-            <!--<li><?php echo $this->Html->link('Respaldos', 'http://localhost/mybackups/import.php', array('target'=>'_blank'));?></li>-->
-            <!--<li><?php echo $this->Html->link(__('Reportes'),'/report_manager/reports');?></li>-->
-            <!--<li><?php echo $this->Html->link(__('Calendario'),'/full_calendar');?></li>--> 
           </ul>
         </li>
       <li>

--- a/View/Elements/menues/menu-sa.ctp
+++ b/View/Elements/menues/menu-sa.ctp
@@ -76,13 +76,10 @@
             <li><?php echo $this->Html->link(__('Instituciones'),'/centros'); ?></li>
             <li><?php echo $this->Html->link(__('Alumnos por Sección [nominal]'), '/cursos_inscripcions');?></li>
             <!--<li><?php echo $this->Html->link(__('Alumnos por Unidad Curricular'), '/inscripcions_materias');?></li>-->
-            <li><?php echo $this->Html->link(__('Alumnos por Sección [cuantitativo]'), '/matriculas');?></li>
-            <li><?php echo $this->Html->link(__('Ingresantes 2019'), '/ingresantes');?></li>
-            <li><?php echo $this->Html->link(__('Inscriptos 2019'), '/vacantes');?></li>
+            <li><?php echo $this->Html->link(__('Inscripciones 2018 [cuantitativo]'), '/matriculas');?></li>
+            <li><?php echo $this->Html->link(__('Ingresantes 2019 [cuantitativo]'), '/ingresantes');?></li>
+            <li><?php echo $this->Html->link(__('Inscripciones 2019 [cuantitativo]'), '/vacantes');?></li>
             <!--<li><?php echo $this->Html->link(__('Gráficos Estadísticos'), '/graficos'); ?></li>-->
-            <!--<li><?php echo $this->Html->link('Respaldos', 'http://localhost/mybackups/import.php', array('target'=>'_blank'));?></li>
-            <!--<li><?php echo $this->Html->link(__('Reportes'),'/report_manager/reports');?></li>-->
-            <!--<li><?php echo $this->Html->link(__('Calendario'),'/full_calendar');?></li>-->
           </ul>
         </li>
       <li>

--- a/View/Elements/menues/menu-u.ctp
+++ b/View/Elements/menues/menu-u.ctp
@@ -72,13 +72,10 @@
             <li><?php echo $this->Html->link(__('Instituciones'),'/centros'); ?></li>
             <li><?php echo $this->Html->link(__('Alumnos por Sección [nominal]'), '/cursos_inscripcions');?></li>
             <!--<li><?php echo $this->Html->link(__('Alumnos por Unidad Curricular'), '/inscripcions_materias');?></li>-->
-            <li><?php echo $this->Html->link(__('Alumnos por Sección [cuantitativo]'), '/matriculas');?></li>
-            <li><?php echo $this->Html->link(__('Ingresantes 2019'), '/ingresantes');?></li>
-            <li><?php echo $this->Html->link(__('Inscriptos 2019'), '/vacantes');?></li>
-            <!--<li><?php echo $this->Html->link('Respaldos', 'http://localhost/mybackups/import.php', array('target'=>'_blank'));?></li>-->
-            <!--<li><?php echo $this->Html->link(__('Reportes'),'/report_manager/reports');?></li>-->
-            <!--<li><?php echo $this->Html->link(__('Gráficos'), '/graficos'); ?></li>-->
-            <!--<li><?php echo $this->Html->link(__('Calendario'),'/full_calendar');?></li>--> 
+            <li><?php echo $this->Html->link(__('Inscripciones 2018 [cuantitativo]'), '/matriculas');?></li>
+            <li><?php echo $this->Html->link(__('Ingresantes 2019 [cuantitativo]'), '/ingresantes');?></li>
+            <li><?php echo $this->Html->link(__('Inscripciones 2019 [cuantitativo]'), '/vacantes');?></li>
+            <!--<li><?php echo $this->Html->link(__('Gráficos Estadísticos'), '/graficos'); ?></li>-->
           </ul>
         </li>
       <li>

--- a/View/Ingresantes/index.ctp
+++ b/View/Ingresantes/index.ctp
@@ -1,32 +1,59 @@
+<?php
+    // Si el usuario no es Admin, muestro el filtro.
+    if(!$this->Siep->isAdmin()) :
+?>
 <div class="TituloSec">Filtro</div>
 <div id="ContenidoSec">
     <?php echo $this->Form->create('Curso',array('type'=>'get','url'=>'index', 'novalidate' => true));?>
     <div class="row">
-         <div class="col-xs-2">
+        <div class="col-xs-4"> 
+         <!-- Autocomplete -->
+              <input id="AutocompleteForm" class="form-control" placeholder="Buscar institucion por nombre" type="text">
+            <script>
+              $( function() {
+                $( "#AutocompleteForm" ).autocomplete({
+                  source: "<?php echo $this->Html->url(array('controller'=>'Centros','action'=>'autocompleteCentro'));?>",
+                  minLength: 2,
+                  select: function( event, ui ) {
+                    $("#AutocompleteForm").val( ui.item.Centro.sigla );
+
+                    window.location.href = "<?php echo $this->Html->url(array('controller'=>'ingresantes'));?>/index?centro_id="+ui.item.Centro.id;
+                    return false;
+                  }
+                }).autocomplete( "instance" )._renderItem = function( ul, item ) {
+                  return $( "<li>" )
+                      .append( "<div>" +item.Centro.sigla + "</div>" )
+                      .appendTo( ul );
+                };
+              });
+            </script>
+          <!-- End Autocomplete -->
+        </div>  
+         <!--<div class="col-xs-2">
             <div class="input select">
                 <?php
                 echo $this->Form->input('sector', array('options'=>$comboSector, 'empty'=>'- Todos los sectores -', 'label'=>false, 'class' => 'form-control', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'title' => 'Seleccione una opción'));
                 ?>
             </div>
-        </div>
-        <div class="col-xs-2">
+        </div>-->
+        <!--<div class="col-xs-2">
             <div class="input select">
                 <?php
                 echo $this->Form->input('ciudad_id', array('options'=>$comboCiudad, 'empty'=>'- Todas las ciudades -', 'label'=>false, 'class' => 'form-control', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'title' => 'Seleccione una opción'));
                 ?>
             </div>
-        </div>
-
-        <div class="col-xs-2">
+        </div>-->
+        <!--<div class="col-xs-2">
             <div class="text-center">
                 <span class="link">
                     <?php echo $this->Form->button('<span class="glyphicon glyphicon-search"></span> Aplicar filtro', array('class' => 'btn btn-primary')); ?>
                 </span>
             </div>
-        </div>
+        </div>-->
     </div>
     <?php echo $this->Form->end(); ?>
 </div>
+<?php endif; ?>
 <?php
      $ocultar = false;
      if( $current_user['Centro']['nivel_servicio'] === 'Común - Inicial - Primario' ||
@@ -87,8 +114,8 @@
       </tbody>
       <tfoot>
         <tr>
-          <th>
-            <!-- Autocomplete -->
+          <!--<th>
+            <!-- Autocomplete
               <input id="AutocompleteForm" class="form-control" placeholder="Buscar institucion por nombre" type="text">
 
             <script>
@@ -109,9 +136,9 @@
                 };
               });
             </script>
-            <!-- End Autocomplete -->
-          </th>
-          <th>
+            <!-- End Autocomplete
+          </th>-->
+          <!--<th>
               <?php echo $this->Form->create('Vacantes',array('id'=>'formFiltroAnio','type'=>'get','url'=>'index', 'novalidate' => true));?>
 
               <?php
@@ -131,7 +158,7 @@
               ?>
 
               <?php echo $this->Form->end(); ?>
-          </th>
+          </th>-->
           <th>
 
           </th>

--- a/View/Matriculas/index.ctp
+++ b/View/Matriculas/index.ctp
@@ -1,25 +1,22 @@
+<?php
+    // Si la persona que navega no es Admin, muestra el Filtro.
+    if(!$this->Siep->isAdmin()) :
+?>
 <div class="TituloSec">Filtro</div>
 <div id="ContenidoSec">
     <?php echo $this->Form->create('Curso',array('type'=>'get','url'=>'index', 'novalidate' => true));?>
-
     <div class="row">
-        <div class="col-xs-2">
-
+        <!--<div class="col-xs-2">
             <div class="input select">
-
                 <?php
                 echo $this->Form->input('ciclo_id', array('options'=>$comboCiclo /*'empty' => 'Ingrese un ciclo lectivo...'*/ , 'default'=>$cicloIdActual, 'disabled' => true, 'label'=>false, 'class' => 'form-control', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'title' => 'Seleccione una opción'));
                 ?>
             </div>
-
-        </div>
-        <?php
-        // Si la persona que navega no es Admin, muestro autocomplete de todas las secciones
-        if(!$this->Siep->isAdmin()) :
-            ?>
-            <div class="col-xs-2">
+        </div>-->
+            <div class="col-xs-6">
                 <!-- Autocomplete -->
-                <input id="AutocompleteForm" class="form-control" placeholder="Buscar institucion por nombre" type="text">
+                <strong>Nombre de la Institución</strong>
+                <input id="AutocompleteForm" class="form-control" placeholder="Indicar el nombre de la institución" type="text">
                 <script>
                     $( function() {
                         $( "#AutocompleteForm" ).autocomplete({
@@ -40,12 +37,7 @@
                 </script>
                 <!-- End Autocomplete -->
             </div>
-
-            <?php
-        endif;
-        ?>
-
-        <div class="col-xs-2">
+        <!--<div class="col-xs-2">
             <div class="input select">
                 <select name="anio" class="form-control" data-toggle="tooltip" data-placement="bottom">
                     <option value="">Seleccione un año...</option>
@@ -58,8 +50,8 @@
                     ?>
                 </select>
             </div>
-        </div>
-        <div class="col-xs-2">
+        </div>-->
+        <!--<div class="col-xs-2">
             <div class="input select">
                 <select name="division" class="form-control" data-toggle="tooltip" data-placement="bottom">
                     <option value="">Seleccione una division...</option>
@@ -72,23 +64,21 @@
                     ?>
                 </select>
             </div>
-        </div>
+        </div>-->
 
-        <div class="col-xs-2">
+        <!--<div class="col-xs-2">
             <div class="text-center">
                 <span class="link">
                     <?php echo $this->Form->button('<span class="glyphicon glyphicon-search"></span> Aplicar filtro', array('class' => 'submit', 'class' => 'btn btn-primary')); ?>
                 </span>
-            </div>
+            </div>-->
     </div>
-
         <?php echo $this->Form->end(); ?>
     </div>
-</div>
+</div><br>
+<?php endif; ?>
 
-<br>
-
-<div class="TituloSec">Alumnos por sección [Cuantitativo]</div>
+<div class="TituloSec">Inscripciones 2018</div>
 <div id="ContenidoSec">
 
     <div class="table-responsive">

--- a/View/Vacantes/index.ctp
+++ b/View/Vacantes/index.ctp
@@ -1,32 +1,60 @@
+<?php
+    // Si el usuario no es Admin, muestro el filtro.
+    if(!$this->Siep->isAdmin()) :
+?>
 <div class="TituloSec">Filtro</div>
 <div id="ContenidoSec">
     <?php echo $this->Form->create('Curso',array('type'=>'get','url'=>'index', 'novalidate' => true));?>
     <div class="row">
-         <div class="col-xs-2">
+          <div class="col-xs-6">
+              <!-- Autocomplete --> 
+              <strong>Nombre de la Institución</strong>
+              <input id="AutocompleteForm" class="form-control" placeholder="Indique el nombre de la institución" type="text">
+            <script>
+              $( function() {
+                $( "#AutocompleteForm" ).autocomplete({
+                  source: "<?php echo $this->Html->url(array('controller'=>'Centros','action'=>'autocompleteCentro'));?>",
+                  minLength: 2,
+                  select: function( event, ui ) {
+                    $("#AutocompleteForm").val( ui.item.Centro.sigla );
+
+                    window.location.href = "<?php echo $this->Html->url(array('controller'=>'vacantes'));?>/index?centro_id="+ui.item.Centro.id;
+                    return false;
+                  }
+                }).autocomplete( "instance" )._renderItem = function( ul, item ) {
+                  return $( "<li>" )
+                      .append( "<div>" +item.Centro.sigla + "</div>" )
+                      .appendTo( ul );
+                };
+              });
+            </script>
+            <!-- End Autocomplete -->
+            </div>
+        <!--<div class="col-xs-2">
             <div class="input select">
                 <?php
                 echo $this->Form->input('sector', array('options'=>$comboSector, 'empty'=>'- Todos los sectores -', 'label'=>false, 'class' => 'form-control', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'title' => 'Seleccione una opción'));
                 ?>
             </div>
-        </div>
-        <div class="col-xs-2">
+        </div>-->
+        <!--<div class="col-xs-2">
             <div class="input select">
                 <?php
                 echo $this->Form->input('ciudad_id', array('options'=>$comboCiudad, 'empty'=>'- Todas las ciudades -', 'label'=>false, 'class' => 'form-control', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'title' => 'Seleccione una opción'));
                 ?>
             </div>
-        </div>
-
-        <div class="col-xs-2">
+        </div>-->
+        <!--<div class="col-xs-2">
             <div class="text-center">
                 <span class="link">
                     <?php echo $this->Form->button('<span class="glyphicon glyphicon-search"></span> Aplicar filtro', array('class' => 'btn btn-primary')); ?>
                 </span>
             </div>
-        </div>
+        </div>-->
     </div>
     <?php echo $this->Form->end(); ?>
 </div>
+<?php endif; ?>
 <?php
      $ocultar = false;
      if( $current_user['Centro']['nivel_servicio'] === 'Común - Inicial - Primario' ||
@@ -35,7 +63,7 @@
          $ocultar = true;
      }
 ?>
-<div class="TituloSec">Inscriptos 2019</div>
+<div class="TituloSec">Inscripciones 2019</div>
 <div id="ContenidoSec">
     <div class="table-responsive">
       <table id="tablaPieBuscador" class="table table-bordered table-hover table-striped    table-condensed">
@@ -48,11 +76,12 @@
             <?php if(!$ocultar) : ?>
                 <th>Plaza</th>
             <?php endif ?>
+          <th>Tipo</th>
           <th>Matricula</th>
             <?php if(!$ocultar) : ?>
                 <th>VACANTES</th>
             <?php endif ?>
-          <th>Acciones</th>
+          <!--<th>Acciones</th>-->
         </tr>
       </thead>
       <tbody>
@@ -75,6 +104,9 @@
             </td>
             <?php if(!$ocultar) : ?>
             <td>
+              <?php echo $seccion['tipo']; ?>
+            </td>
+            <td>
               <?php echo $seccion['plazas']; ?>
             </td>
             <?php endif ?>
@@ -86,17 +118,17 @@
               <?php echo $seccion['vacantes']; ?>
             </td>
             <?php endif ?>
-            <td >
+            <!--<td >
               <span class="link"><?php echo $this->Html->link('<i class="glyphicon glyphicon-eye-open"></i>', array('controller' => 'Cursos', 'action'=> 'view', $seccion['curso_id']), array('class' => 'btn btn-default', 'escape' => false)); ?></span>
-            </td>
+            </td>-->
           </tr>
         <?php endforeach; ?>
         <?php endif; ?>
       </tbody>
-      <tfoot>
+      <!--<tfoot>
         <tr>
           <th>
-            <!-- Autocomplete -->
+            <!-- Autocomplete 
               <input id="AutocompleteForm" class="form-control" placeholder="Buscar institucion por nombre" type="text">
 
             <script>
@@ -117,7 +149,7 @@
                 };
               });
             </script>
-            <!-- End Autocomplete -->
+            <!-- End Autocomplete 
           </th>
           <th>
               <?php echo $this->Form->create('Vacantes',array('id'=>'formFiltroAnio','type'=>'get','url'=>'index', 'novalidate' => true));?>
@@ -144,7 +176,7 @@
 
           </th>
         </tr>
-      </tfoot>
+      </tfoot>-->
     </table>
 
       <script>


### PR DESCRIPTION
## Descripción
Para visualizaciones de Matrícula 2018:
- Cambia denominación de ALUMNOS POR SECCIÓN [CUANTITATIVO] a INSCRIPCIONES 2018 [CUANTITATIVO].
- En INSCRIPCIONES 2018 [CUANTITATIVO]: Sólo filtra instituciones; Oculta filtro para usuarios admin.
- En SECCIONES --> VIEW, modifica visualización de MATRÍCULA y VACANTES. 
Para visualizaciones de Matrícula 2019:
- Cambia denominación de INSCRIPTOS 2019 a INSCRIPCIONES 2019 [CUANTITATIVO].
- En INSCRIPCIONES 2019 [CUANTITATIVO]: Sólo filtra instituciones; Oculta filtro para usuarios "admin"; Agrega en tabla columna "Tipo"; Oculta en tabla acceso al VIEW de secciones.
  
## Motivación y Contexto
Resuelve confusión para identificar matrícula 2018 de 2019.

## Tipo de cambios
- [x] Bug fix (cambio que no rompe la api existente y resuelve un issue)
- [ ] Nueva funcionalidad (cambio que no rompe la api existente y agrega funcionalidad)
- [ ] Cambio en la api (un fix o funcionalidad que modifica la api existente).