### PR TITLE
Habilita EDITAR PERSONAS sin reestricciones

### DIFF
--- a/Controller/PersonasController.php
+++ b/Controller/PersonasController.php
@@ -223,10 +223,12 @@ class PersonasController extends AppController {
 			$this->Session->setFlash('Persona no válida', 'default', array('class' => 'alert alert-warning'));
 			$this->redirect(array('action' => 'index'));
 		}
+		/*
 		if(!$this->adminCanEdit($id)) {
 			$this->Session->setFlash('No tiene permisos para editar a esta persona, no pertenece a su establecimiento', 'default', array('class' => 'alert alert-warning'));
 			$this->redirect(array('action' => 'index'));
 		}
+		*/
 		if (!empty($this->data)) {
 		  //abort if cancel button was pressed
         	if(isset($this->params['data']['cancel'])) {


### PR DESCRIPTION
## Descripción
Provisoriamente deshabilita la reestricción de usuarios para EDITAR datos de PERSONA de ALUMNOS.

## Motivación y Contexto
Las salas de 5 años y 6tos grados con alumnos INSCRIPTOS 2019, no pueden EDITAR datos de PERSONA de sus alumnos 2018.

## Tipo de cambios
- [x] Bug fix (cambio que no rompe la api existente y resuelve un issue)
- [ ] Nueva funcionalidad (cambio que no rompe la api existente y agrega funcionalidad)
- [ ] Cambio en la api (un fix o funcionalidad que modifica la api existente).