### PR TITLE
Oculta secciones con matrícula 0 de INSCRIPCIONES 2018 CUANTITATIVO

### DIFF
--- a/Controller/MatriculasController.php
+++ b/Controller/MatriculasController.php
@@ -48,7 +48,7 @@ class MatriculasController extends AppController
         $this->paginate = array(
             'contain' => array('Centro'),
             'limit' => 10,
-            'conditions' => array('Curso.division !=' => '', 'Curso.status =' => 1),
+            'conditions' => array('Curso.division !=' => '', 'Curso.status =' => 1, 'Curso.matricula !=' => 0),
             'order' => array('Curso.centro_id' => 'asc' )
         );
         $this->redirectToNamed();


### PR DESCRIPTION
## Descripción
Oculta del index de INSCRIPCIONES 2018, las secciones creadas para el 2019 que no tienen matrículas en el 2018.

## Motivación y Contexto
Las secciones creadas para el 2019 no deben visualizarse en INSCRIPCIONES 2018.
 
## Tipo de cambios
- [x] Bug fix (cambio que no rompe la api existente y resuelve un issue)
- [ ] Nueva funcionalidad (cambio que no rompe la api existente y agrega funcionalidad)
- [ ] Cambio en la api (un fix o funcionalidad que modifica la api existente).