### PR TITLE
Adapta para el nivel Adultos la visualización de documentación presentada en inscripciones 

### DIFF
--- a/Controller/InscripcionsController.php
+++ b/Controller/InscripcionsController.php
@@ -385,6 +385,13 @@ class InscripcionsController extends AppController {
                                 $estadoDocumentacion = "PENDIENTE";   
                         }                        
                     break;
+                case 'Adultos - Secundario':
+                    if(($this->request->data['Inscripcion']['fotocopia_dni'] ==1) && ($this->request->data['Inscripcion']['certificado_septimo'] ==1)) {
+                        $estadoDocumentacion = "COMPLETA";
+                    } else {
+                        $estadoDocumentacion = "PENDIENTE";   
+                    }                        
+                    break;    
                 default:
                        $estadoDocumentacion = "PENDIENTE";
             }
@@ -523,6 +530,13 @@ class InscripcionsController extends AppController {
                         $estadoDocumentacion = "PENDIENTE";   
                     }                        
                     break;
+                case 'Adultos - Secundario':
+                    if(($this->request->data['Inscripcion']['fotocopia_dni'] ==1) && ($this->request->data['Inscripcion']['certificado_septimo'] ==1)) {
+                        $estadoDocumentacion = "COMPLETA";
+                    } else {
+                        $estadoDocumentacion = "PENDIENTE";   
+                    }                        
+                    break;    
                 default:
                     //$estadoDocumentacion = "PENDIENTE";
             }
@@ -733,6 +747,7 @@ class InscripcionsController extends AppController {
         *  Sino sí es usuario de otro nivel ve los correspondiente.
         */
 		$userCentroId = $this->getUserCentroId();
+        $userCentroNivel = $this->getUserCentroNivel($userCentroId);
         $nivelCentro = $this->Inscripcion->Centro->find('list', array('fields'=>array('nivel_servicio'), 'contain'=>false, 'conditions'=>array('id'=>$userCentroId)));
         $userRol = $this->Auth->user('role');
 		$this->Inscripcion->Curso->recursive = 0;
@@ -769,7 +784,7 @@ class InscripcionsController extends AppController {
 			$personaId = $this->Alumno->find('list', array('fields'=>array('persona_id'), 'contain'=>false));
 		}
 		/* FIN */
-        $this->set(compact('ciclos', 'centros', 'cursos', 'materias', 'empleados', 'cicloIdActual','cicloIdUltimo'));
+        $this->set(compact('ciclos', 'centros', 'cursos', 'materias', 'empleados', 'cicloIdActual','cicloIdUltimo', 'userCentroNivel'));
 	}
 
 	private function __getCodigo($ciclo, $personaDocString){

--- a/Controller/UsersController.php
+++ b/Controller/UsersController.php
@@ -35,6 +35,13 @@ class UsersController extends AppController {
 				break;
 		}
 		/* FIN */
+		/* FUNCIÓN PRIVADA "LISTS" (INICIO).
+        *Si se ejecutan las acciones add/edit activa la función privada "lists".
+		
+		if ($this->ifActionIs(array('add', 'edit'))) {
+			$this->__lists();
+		}
+		/* FIN */
     }     
      
 	//Acción para redirigir a los usuarios con rol usuario común
@@ -54,7 +61,10 @@ class UsersController extends AppController {
 		$userCentroNivel = $this->getUserCentroNivel($userCentroId);
 		//Obtención del puesto del usuario.
 		$userPuesto = $this->Auth->user('puesto');
-		$this->set(compact('users', 'nombreCentro', 'userCentroNivel', 'userPuesto'));
+		//Obtención del nivel del centro del usuario.
+		$userCentroId = $this->getUserCentroId();
+        $userCentroNivel = $this->getUserCentroNivel($userCentroId);
+		$this->set(compact('users', 'nombreCentro', 'userCentroNivel', 'userPuesto', 'userCentroNivel'));
     	$this->render('/Users/usuario');
     }
 	
@@ -91,7 +101,7 @@ class UsersController extends AppController {
 			$conditions['User.username ='] = $this->params['named']['username'];
 		}
 		$users = $this->paginate('User', $conditions);
-     	$this->set(compact('users'));
+		$this->set(compact('users'));
     }
 
 	public function view($id = null) {
@@ -193,6 +203,11 @@ class UsersController extends AppController {
 		$this->Session->setFlash('El usuario no pudo ser reactivado', 'default', array('class' => 'alert alert-danger'));
         $this->redirect(array('action' => 'index'));
     }
-	
+
+    //Métodos privados
+	/*
+	private function __lists(){
+	}
+	*/
 }
 ?>

--- a/View/Elements/forms/form_inscripcion_add.ctp
+++ b/View/Elements/forms/form_inscripcion_add.ctp
@@ -242,6 +242,7 @@
               <?php echo $this->Form->input('fotocopia_dni', array('between' => '<br>', 'class' => 'form-control', 'label' => false, 'type' => 'checkbox', 'before' => '<label class="checkbox">', 'after' => '<br><i></i><br>Fotocopia DNI</label>'));?>
             </span>
           </div>
+        <?php if ($userCentroNivel != 'Adultos - Secundario') : ?>  
           <div class="input-group">
           <span class="input-group-addon">
             <?php echo $this->Form->input('partida_nacimiento_alumno', array('between' => '<br>', 'class' => 'form-control', 'label' => false, 'type' => 'checkbox', 'before' => '<label class="checkbox">', 'after' => '<br><i></i><br>Partida de Nacimiento Alumno</label>'));?>
@@ -252,6 +253,7 @@
             <?php echo $this->Form->input('certificado_vacunas', array('between' => '<br>', 'class' => 'form-control', 'label' => false, 'type' => 'checkbox', 'before' => '<label class="checkbox">', 'after' => '<br><i></i><br>Certificado Vacunación</label>'));?>
           </span>
           </div>
+        <?php endif; ?>  
           <!--
           <div class="input-group">
             <span class="input-group-addon">

--- a/View/Users/usuario.ctp
+++ b/View/Users/usuario.ctp
@@ -171,7 +171,8 @@
 	</div>
 !-->
 <?php endif; ?>	
-<!-- Visualizable por todos los roles de usuarios -->	
+<!-- Visualizable por todos los roles de usuarios excepto los de Primario y Secundario de adultos. -->
+<?php if($userCentroNivel != 'Adultos - Secundario' && $userCentroNivel != 'Adultos - Primario') : ?>
 	<div class="panel panel-primary">
 	  <div class="panel-heading">
 	    <h3 class="panel-title">INICIAL, PRIMARIA Y SECUNDARIA | INSCRIPCIONES POR HERMANOS</h3>
@@ -196,4 +197,5 @@
 	    <li class="list-group-item">3º PASO | "Revisión de la inscripción recién registrada": verifique en "Datos de Alta" figure el nombre correcto del hermano.</li>
 	  </ul>
 	</div>
+<?php endif; ?>	
 </div>


### PR DESCRIPTION
## Descripción
El nivel Adultos, sólo requiere, al momento de inscribir, la presentación de fotocopia de DNI y certificado de 7mo grado. 

## Motivación y Contexto
Mostraba erróneamente la presentación de documentación que no se requiere en el nivel de Adultos.

## Tipo de cambios
- [x] Bug fix (cambio que no rompe la api existente y resuelve un issue)
- [ ] Nueva funcionalidad (cambio que no rompe la api existente y agrega funcionalidad)
- [ ] Cambio en la api (un fix o funcionalidad que modifica la api existente).