### PR TITLE
Ajusta en admin permiso de EDICIÓN de PERSONA en alumnos.

### DIFF
--- a/Controller/PersonasController.php
+++ b/Controller/PersonasController.php
@@ -260,12 +260,17 @@ class PersonasController extends AppController {
 			$this->Session->setFlash('Persona no válida', 'default', array('class' => 'alert alert-warning'));
 			$this->redirect(array('action' => 'index'));
 		}
-		/*
-		if(!$this->adminCanEdit($id)) {
-			$this->Session->setFlash('No tiene permisos para editar a esta persona, no pertenece a su establecimiento', 'default', array('class' => 'alert alert-warning'));
-			$this->redirect(array('action' => 'index'));
-		}
-		*/
+		//Consulta sí es familiar y/o alumno para definir permiso de edición.
+		$personaEsFamiliarAlumnoArray = $this->Persona->findById($id,'familiar, alumno');
+	    $personaEsFamiliar = $personaEsFamiliarAlumnoArray['Persona']['familiar'];
+		$personaEsAlumno = $personaEsFamiliarAlumnoArray['Persona']['alumno'];
+		//Sí no es familiar no limita la edición a los "admin" del centro.
+		if ($personaEsFamiliar == 0 || $personaEsAlumno == 1) :
+			if(!$this->adminCanEdit($id)) {
+				$this->Session->setFlash('No tiene permisos para editar a esta persona, no pertenece a su establecimiento', 'default', array('class' => 'alert alert-warning'));
+				$this->redirect(array('action' => 'index'));
+			}
+		endif;
 		if (!empty($this->data)) {
 		  //abort if cancel button was pressed
         	if(isset($this->params['data']['cancel'])) {


### PR DESCRIPTION
## Descripción
 Permite que los usuarios "admin" sólo editen datos de PERSONA en ALUMNOS inscriptos en el CICLO ACTUAL y que correspondan a la INSTITUCIÓN. 

 Permite que los usuarios "admin" editen sin reestricción datos de PERSONA de FAMILIARES. 

## Tipo de cambios
- [x] Bug fix (cambio que no rompe la api existente y resuelve un issue)
- [ ] Nueva funcionalidad (cambio que no rompe la api existente y agrega funcionalidad)
- [ ] Cambio en la api (un fix o funcionalidad que modifica la api existente).