### PR TITLE
Agrega imprimir CONSTANCIAS DE ALUMNO sólo desde las INSCRIPCIONES de…

### DIFF
--- a/Controller/InscripcionsController.php
+++ b/Controller/InscripcionsController.php
@@ -186,8 +186,25 @@ class InscripcionsController extends AppController {
         //Obtención del id del centro para permitir editar sólo a los usuarios "admin" del mismo centro de la inscripción o a los "superadmin" o "usuarios".
         $centroInscripcionArray = $this->Inscripcion->findById($id, 'centro_id');
         $centroInscripcion = $centroInscripcionArray['Inscripcion']['centro_id'];
+        //Obtención del id del ciclo para permitir descargar CONSTANCIA DE ALUMNO REGULAR sólo sí coincide con el ciclo actual.
+        $cicloInscripcionArray = $this->Inscripcion->findById($id, 'ciclo_id');
+        $cicloInscripcion = $cicloInscripcionArray['Inscripcion']['ciclo_id'];
+        // Obtención del ciclo actual.
+        $hoyArray = getdate();
+        $nombreCicloActual = $hoyArray['year'];
+        $this->loadModel('Ciclo');
+        $this->Ciclo->recursive = 0;
+        $this->Ciclo->Behaviors->load('Containable');
+        /*
+        $cicloActual = $this->Ciclo->find('first', array(
+            'contain' => false,
+            'conditions' => array('nombre' => $hoyArray['year'])
+        ));
+        */
+        $cicloIdActualArray = $this->Ciclo->findByNombre($nombreCicloActual, 'id');
+        $cicloIdActual = $cicloIdActualArray['Ciclo']['id']; 
         //Envío de dato a la vista.
-        $this->set(compact('estadoInscripcion', 'userCentroNivel', 'userCentroId', 'centroInscripcion'));
+        $this->set(compact('estadoInscripcion', 'userCentroNivel', 'userCentroId', 'centroInscripcion', 'cicloInscripcion', 'cicloIdActual'));
     }
 
 	public function add() {

--- a/View/Inscripcions/view.ctp
+++ b/View/Inscripcions/view.ctp
@@ -152,9 +152,10 @@
  			      <div class="subtitulo">Opciones</div>
                   <div class="opcion"><?php echo $this->Html->link(__('Listar Inscripciones'), array('action' => 'index')); ?></div>
                 <?php 
-                //Se visualiza solo sí la inscripción del alumno tiene estado CONFIRMADA o se trata de un "superusuario", "usuario" o "admin" del mismo centro que la inscripción. 
+                //Se visualiza solo sí se trata de un "superusuario", "usuario" o "admin" del mismo centro que la inscripción. 
                   if($current_user['role'] == 'superadmin' || $current_user['role'] == 'usuario' || $userCentroId == $centroInscripcion):
-                    if($estadoInscripcion === 'CONFIRMADA'): ?>
+                    // y sí la inscripción del alumno tiene estado CONFIRMADA y es del ciclo actual. 
+                    if($estadoInscripcion === 'CONFIRMADA' && $cicloInscripcion == $cicloIdActual): ?>
                         <div class="opcion"><a href="http://api.sieptdf.org/api/constancia/<?php echo $inscripcion['id'];?>">Constancia de Inscripción</a></div>
                         <div class="opcion"><a href="http://api.sieptdf.org/api/constancia_regular/<?php echo $inscripcion['id'];?>">Constancia de Alumno Regular</a></div>
                     <?php endif; ?>


### PR DESCRIPTION
## Descripción
Habilita la impresión de CONSTANCIAS DE ALUMNOS REGULARES sólo desde las INSCRIPCIONES del CICLO ACTUAL.

## Motivación y Contexto
Resuelve la impresión de CONSTANCIAS DE ALUMNOS de INSCRIPCIONES 2017 con fecha actual.
 
## Tipo de cambios
- [x] Bug fix (cambio que no rompe la api existente y resuelve un issue)
- [ ] Nueva funcionalidad (cambio que no rompe la api existente y agrega funcionalidad)
- [ ] Cambio en la api (un fix o funcionalidad que modifica la api existente).