### PR TITLE
Corrige habilitar egreso en 6tos de Colegios con Bachiller/Técnico

### DIFF
--- a/View/Cursos/view.ctp
+++ b/View/Cursos/view.ctp
@@ -89,11 +89,12 @@
 					<?php
 						if($curso['Curso']['anio'] == '6to')
 						{
+							/*Deben mostrar la opción "EGRESAR" los 7mos de las secciones con orientación técnica y los 6tos de las secciones con orientación bachiller*/
 							if(
 								($curso['Centro']['cue'] == '940007700') ||
-								($curso['Centro']['cue'] == '940008300') ||
+								($curso['Centro']['cue'] == '940008300')/* ||
 								($curso['Centro']['cue'] == '940015900') ||
-								($curso['Centro']['cue'] == '940015700')
+								($curso['Centro']['cue'] == '940015700')*/
 							) {
 								$showEgreso = false;
 							} else {


### PR DESCRIPTION
## Descripción
Los colegios con Bachiller y Técnico tienen secciones con egresos en 6to y 7mo.

## Motivación y Contexto
Resuelve provisoriamente el egreso en Colegios con titulación mixta. Queda pendiente resolver una lógica específica para estos casos.

## Tipo de cambios
- [x] Bug fix (cambio que no rompe la api existente y resuelve un issue)
- [ ] Nueva funcionalidad (cambio que no rompe la api existente y agrega funcionalidad)
- [ ] Cambio en la api (un fix o funcionalidad que modifica la api existente).