### PR TITLE
Corrige espacio en tarjeta para visualizar nombre de titulación.

### DIFF
--- a/View/Elements/curso.ctp
+++ b/View/Elements/curso.ctp
@@ -8,7 +8,7 @@
         <span class="name"><span class="glyphicon glyphicon-info-sign"></span> <b>Turno: </b> <?php echo $curso['Curso']['turno']; ?></span></br>
         <span class="name"><span class="glyphicon glyphicon-info-sign"></span> <b>Tipo: </b> <?php echo $curso['Curso']['tipo']; ?></span></br>
     <?php if (array_key_exists($curso['Curso']['centro_id'], $centrosIds)): ?>
-        <span class="name"><span class="glyphicon glyphicon-info-sign"></span> <b>Titulación: </b> <?php echo $titulacionesNombres[$curso['Curso']['titulacion_id']]; ?></span>
+        <span class="name"><span class="glyphicon glyphicon-info-sign"></span> <b>Titulación: </br></b> <?php echo $titulacionesNombres[$curso['Curso']['titulacion_id']]; ?></span>
     <?php endif; ?>
         <hr />
         <div class="text-right">


### PR DESCRIPTION
## Descripción
 Los nombres de las titulaciones en su mayoría son largos. Por esa razón se trabaja con el campo "nombre_abreviado".

## Motivación y Contexto
 Las titulaciones con nombre muy largo generan desproporciones en tarjetas y tablas.

## Tipo de cambios
- [x] Bug fix (cambio que no rompe la api existente y resuelve un issue)
- [ ] Nueva funcionalidad (cambio que no rompe la api existente y agrega funcionalidad)
- [ ] Cambio en la api (un fix o funcionalidad que modifica la api existente).