### PR TITLE
Agrega información de titulaciones en los listados INSCRIPCIONES 2018 Y 2019

### DIFF
--- a/Controller/MatriculasController.php
+++ b/Controller/MatriculasController.php
@@ -144,8 +144,15 @@ class MatriculasController extends AppController
                 'fields'=> array('Curso.division','Curso.division')
             ));
         }
-
-        $this->set(compact('matriculas','comboAnio','comboDivision','comboCiclo','cicloIdUltimo','cicloIdActual'));
+        //Obtención de los nombres de las titulaciones para mostrar en las secciones.
+        $this->loadModel('Titulacion');
+        $this->Titulacion->recursive = 0;
+        $this->Titulacion->Behaviors->load('Containable');
+        $titulacionesNombres = $this->Titulacion->find('list', array(
+            'fields'=>array('nombre_abreviado'),
+            'contain'=>false,
+            'conditions'=>array('status'=>1)));
+        $this->set(compact('matriculas','comboAnio','comboDivision','comboCiclo','cicloIdUltimo','cicloIdActual', 'titulacionesNombres'));
   	}
 
     /*

--- a/Controller/VacantesController.php
+++ b/Controller/VacantesController.php
@@ -126,7 +126,16 @@ class VacantesController extends AppController
             // Manejar error de API
         }
 
-        $this->set(compact('matriculas_por_seccion','cicloIdUltimo','cicloIdActual','comboCiclo','comboCiudad','comboSector'));
+        //Obtención de los nombres de las titulaciones para mostrar en las secciones.
+        $this->loadModel('Titulacion');
+        $this->Titulacion->recursive = 0;
+        $this->Titulacion->Behaviors->load('Containable');
+        $titulacionesNombres = $this->Titulacion->find('list', array(
+            'fields'=>array('nombre_abreviado'),
+            'contain'=>false,
+            'conditions'=>array('status'=>1)));
+        
+        $this->set(compact('matriculas_por_seccion','cicloIdUltimo','cicloIdActual','comboCiclo','comboCiudad','comboSector', 'titulacionesNombres'));
     }
 
     public function recuento()

--- a/View/Elements/cursosInscripcion_lista.ctp
+++ b/View/Elements/cursosInscripcion_lista.ctp
@@ -30,7 +30,7 @@
                     <?php  endif;  ?>
                 </td>
                 <td><?php echo $cursosInscripcion['Ciclo']['nombre']; ?> </td>
-                <td><?php echo $cursosInscripcion['Centro']['nombre']; ?> </td>
+                <td><?php echo $cursosInscripcion['Centro']['sigla']; ?> </td>
                 <td><?php echo $cursosInscripcion['Curso']['anio']." ".$cursosInscripcion['Curso']['division']; ?> </td>
                 <td><?php echo $cursosInscripcion['Curso']['turno']; ?> </td>
                 <td><?php echo $cursosInscripcion['Persona']['documento_nro']; ?> </td>

--- a/View/Matriculas/index.ctp
+++ b/View/Matriculas/index.ctp
@@ -77,7 +77,14 @@
     </div>
 </div><br>
 <?php endif; ?>
-
+<?php
+     $ocultar = false;
+     if( $current_user['Centro']['nivel_servicio'] === 'Común - Inicial - Primario' ||
+         $current_user['Centro']['nivel_servicio'] === 'Común - Inicial' ||
+         $current_user['Centro']['nivel_servicio'] === 'Común - Primario' ) {
+         $ocultar = true;
+     }
+?>
 <div class="TituloSec">Inscripciones 2018</div>
 <div id="ContenidoSec">
 
@@ -90,6 +97,9 @@
           <th><?php echo $this->Paginator->sort('division', 'Division');?></th>
           <th><?php echo $this->Paginator->sort('tipo', 'Tipo');?></th>
           <th><?php echo $this->Paginator->sort('turno', 'Turno');?></th>
+        <?php if(!$ocultar) : ?>
+          <th><?php echo $this->Paginator->sort('titulacion', 'Titulación');?></th>
+        <?php endif; ?>  
           <th><?php echo $this->Paginator->sort('plazas', 'Plazas');?></th>
           <th><?php echo $this->Paginator->sort('matricula', 'Matriculas');?></th>
           <th><?php echo $this->Paginator->sort('vacantes', 'Vacantes');?></th>
@@ -114,6 +124,11 @@
             <td>
               <?php echo $matricula['Curso']['turno']; ?>
             </td>
+          <?php if(!$ocultar) : ?>  
+            <td>
+              <?php echo $titulacionesNombres[$matricula['Curso']['titulacion_id']]; ?>
+            </td>
+          <?php endif; ?>  
             <td>
               <?php echo $matricula['Curso']['plazas']; ?>
             </td>

--- a/View/Vacantes/index.ctp
+++ b/View/Vacantes/index.ctp
@@ -75,7 +75,8 @@
           <th>Division</th>
           <th>Tipo</th>
           <?php if(!$ocultar) : ?>
-              <th>Plaza</th>
+            <th>Titulación</th>
+            <th>Plaza</th>
           <?php endif ?>
           <th>Matricula</th>
           <?php if(!$ocultar) : ?>
@@ -102,9 +103,12 @@
             <td>
               <?php echo $seccion['division']; ?>
             </td>
-            <?php if(!$ocultar) : ?>
             <td>
               <?php echo $seccion['tipo']; ?>
+            </td>
+            <?php if(!$ocultar) : ?>
+            <td>
+              <?php echo $titulacionesNombres[$seccion['titulacion_id']]; ?>
             </td>
             <td>
               <?php echo $seccion['plazas']; ?>


### PR DESCRIPTION
## Descripción
 Agrega información de la titulación de la SECCIÓN en los listados INSCRIPCIONES 2018 y 2019.
 
## Motivación y Contexto
 Resuelve no tener que agregar a la denominación de la DIVISIÓN la orientación/especialidad (Ej: 4to A ECO).

## Tipo de cambios
- [ ] Bug fix (cambio que no rompe la api existente y resuelve un issue)
- [x] Nueva funcionalidad (cambio que no rompe la api existente y agrega funcionalidad)
- [ ] Cambio en la api (un fix o funcionalidad que modifica la api existente).