### PR TITLE
hotfix(Exportar Vacantes)

### DIFF
--- a/Controller/VacantesController.php
+++ b/Controller/VacantesController.php
@@ -141,7 +141,7 @@ class VacantesController extends AppController
             $showBtnExcel = true;
             $queryExportarExcel = [];
             $queryExportarExcel['export'] = 'excel';
-            $queryExportarExcel['por_pagina'] = 'all';
+            $queryExportarExcel['por_pagina'] = '1000000'; // Hardcode (hay un problema de paginacion en el API)
             $queryExportarExcel = array_merge($apiParams,$queryExportarExcel);
         }
 


### PR DESCRIPTION
El API no realiza la paginacion correctamente en consultas SQL sin Eloquent, es por esto que se fuerza a exportar todos los resultados del filtro soliticado. 

Abierto ISSUE para parchar