### PR TITLE
En Alumnos Nominal sólo habilita impresión sí se busca por ciclo.

### DIFF
--- a/Controller/CursosInscripcionsController.php
+++ b/Controller/CursosInscripcionsController.php
@@ -155,21 +155,21 @@ class CursosInscripcionsController extends AppController {
 		if(empty($this->params['named']['estado_inscripcion'])) {
 			$conditions['Inscripcion.estado_inscripcion ='] = 'CONFIRMADA';
 			$queryExportacionExcel['estado_inscripcion'] = $conditions['Inscripcion.estado_inscripcion ='];
-			$showExportBtn++;
+			//$showExportBtn++;
 
 			$defaultForm['estado_inscripcion'] = $conditions['Inscripcion.estado_inscripcion ='];
 
 		} else {
 			$conditions['Inscripcion.estado_inscripcion ='] = $this->params['named']['estado_inscripcion'];
 			$queryExportacionExcel['estado_inscripcion'] = $this->params['named']['estado_inscripcion'];
-			$showExportBtn++;
+			//$showExportBtn++;
 
 			$defaultForm['estado_inscripcion'] = $this->params['named']['estado_inscripcion'];
 		}
 		if(!empty($this->params['named']['centro_id'])) {
 			$conditions['Inscripcion.centro_id ='] = $this->params['named']['centro_id'];
 			$queryExportacionExcel['centro_id'] = $this->params['named']['centro_id'];
-			$showExportBtn++;
+			//$showExportBtn++;
 
 			$defaultForm['centro_id'] = $this->params['named']['centro_id'];
 		}

--- a/View/Elements/formsSearch/formSearch_cursosInscripcion.ctp
+++ b/View/Elements/formsSearch/formSearch_cursosInscripcion.ctp
@@ -1,7 +1,7 @@
 <?php echo $this->Form->create('CursosInscripcion',array('type'=>'get','url'=>'index', 'novalidate' => true));?>
 
 <!-- COMBO DISPLAY -->
-<div class="form-group">
+<!--<div class="form-group">
     <div class="input select">
         <select name="modo" class="form-control" data-toggle="tooltip" data-placement="bottom">
             <option value="tarjeta">Ver resultados como tarjetas</option>
@@ -9,7 +9,7 @@
             ?>
         </select>
     </div>
-</div>
+</div>-->
 
 <!-- COMBO CENTROS -->
 <div class="form-group">
@@ -47,7 +47,7 @@
 <div class="form-group">
     <div class="input select">
         <?php
-        echo $this->Form->input('ciclo_id', array('label' => false, 'empty'=>'Seleccione un ciclo...', 'options'=>$comboCiclo, 'default'=>$defaultForm['ciclo_id'], 'class' => 'form-control'));	?>
+        echo $this->Form->input('ciclo_id', array('label' => '* Debe indicar un CICLO para imprimir listado.', 'empty'=>'Seleccione un ciclo ( * Obligatorio )', 'options'=>$comboCiclo, 'default'=>$defaultForm['ciclo_id'], 'class' => 'form-control'));	?>
     </div>
 </div>
 


### PR DESCRIPTION
## Descripción
En ALUMNOS POR SECCIÓN NOMINAL, sólo se visualizará el botón "Exportar resultados a excel" cuando se indique un CICLO en el campo correspondiente al cuadro de BÚSQUEDA.  

## Motivación y Contexto
Resuelve el problema de intentar EXPORTAR A EXCEL sin indicar un CICLO específico y por esta causa, el sistema indica error.
 
## Tipo de cambios
- [ ] Bug fix (cambio que no rompe la api existente y resuelve un issue)
- [x] Nueva funcionalidad (cambio que no rompe la api existente y agrega funcionalidad)
- [ ] Cambio en la api (un fix o funcionalidad que modifica la api existente).