### PR TITLE
fix (Checkbox) Repitencia y Promocion 

### DIFF
--- a/View/Cursos/view.ctp
+++ b/View/Cursos/view.ctp
@@ -61,11 +61,12 @@
 					)); ?>
 				</div>
 				<?php
-					// Por defecto no muestro la promocion ni el egreso
+					// Por defecto se ocultan las siguientes opciones
 					$showPromocion = false;
 					$showEgreso = false;
+					$showRepetir = true;
 
-					if ($curso['Curso']['division'] != '') {
+				if ($curso['Curso']['division'] != '') {
 						/*  Los unicos 6to que promocionan
 							940007700 CEPET
 							940008300 EPET
@@ -155,6 +156,15 @@
 							)); ?>
 						</div>
 					<?php endif; ?>
+
+				<?php  if($showRepetir) : ?>
+					<div class="opcion"><?php echo $this->Html->link(__('Repitencia'), array('action' => 'index','controller' => 'Repitentes',
+							'centro_id'=>$curso['Centro']['id'],
+							'curso_id'=>$curso['Curso']['id'],
+							'ciclo' =>$cicloActual['Ciclo']['nombre']
+						)); ?>
+					</div>
+				<?php endif; ?>
 
 					<div class="opcion"><?php echo $this->Html->link(__('Reubicar'), array('action' => 'index','controller' => 'Reubicacion',
 							'centro_id'=>$curso['Centro']['id'],

--- a/View/Elements/promocion_lista.ctp
+++ b/View/Elements/promocion_lista.ctp
@@ -20,6 +20,7 @@
                 if(
                     $cursosInscripcion['Inscripcion']['estado_inscripcion']=='CONFIRMADA' &&
                     $cursosInscripcion['Inscripcion']['promocion_id'] == null &&
+                    $cursosInscripcion['Inscripcion']['repitencia_id'] == null &&
                     $cursosInscripcion['Inscripcion']['ciclo_id'] == $cicloaPromocionar['id']
                 ) :
                 ?>

--- a/View/Elements/repitentes_lista.ctp
+++ b/View/Elements/repitentes_lista.ctp
@@ -20,6 +20,7 @@
                 if(
                     $cursosInscripcion['Inscripcion']['estado_inscripcion']=='CONFIRMADA' &&
                     $cursosInscripcion['Inscripcion']['repitencia_id'] == null  &&
+                    $cursosInscripcion['Inscripcion']['promocion_id'] == null  &&
                     $cursosInscripcion['Inscripcion']['ciclo_id'] == $cicloaPromocionar['id']
                 ) :
                 ?>


### PR DESCRIPTION
El checkbox no se muestra si la inscripcion del ciclo actual ya dispone de promocion_id o repitencia_id

Se agrega boton de repetir al menu de opciones en secciones