### PR TITLE
Agrega ANULACIÓN de INSCRIPCIONES 2020 sólo para usuarios específicos.

### DIFF
--- a/Model/Inscripcion.php
+++ b/Model/Inscripcion.php
@@ -268,7 +268,7 @@ class Inscripcion extends AppModel {
 		),
 		'estado_inscripcion' => array(
 			'valid' => array(
-			'rule' => array('inList', array('CONFIRMADA','NO CONFIRMADA','BAJA','EGRESO')),
+			'rule' => array('inList', array('CONFIRMADA','NO CONFIRMADA','BAJA','EGRESO','ANULADA')),
 			'message' => 'Indicar una opción',
 			'allowEmpty' => false
 				)

--- a/View/Elements/forms/form_inscripcion_edit.ctp
+++ b/View/Elements/forms/form_inscripcion_edit.ctp
@@ -68,7 +68,7 @@
         echo $this->Form->input('legajo_nro', array('type' => 'hidden'));
     ?><br>
     <?php
-        $estados_inscripcion = array('CONFIRMADA'=>'CONFIRMADA','NO CONFIRMADA'=>'NO CONFIRMADA','BAJA'=>'BAJA','EGRESO'=>'EGRESO');
+        $estados_inscripcion = array('CONFIRMADA'=>'CONFIRMADA','NO CONFIRMADA'=>'NO CONFIRMADA','BAJA'=>'BAJA','EGRESO'=>'EGRESO','ANULADA'=>'ANULADA');
         //Si el número de legajo tiene la denominación "SINVACANTE", deshabilita la modificación del estado de inscripción.
         if ($sinVacante === 'SINVACANTE') {
         echo $this->Form->input('estado_inscripcion', array('default'=>$estadoInscripcionAnteriorArray['Inscripcion']['estado_inscripcion'],'label'=>'Estado de la inscripción (*Obligatorio)', 'disabled' =>true, 'empty' => 'Ingrese un estado de inscripción...', 'options'=>$estados_inscripcion, 'class' => 's2_general form-control', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'title' => 'Seleccione una opción'));

--- a/View/Elements/formsSearch/formSearch_cursosInscripcion.ctp
+++ b/View/Elements/formsSearch/formSearch_cursosInscripcion.ctp
@@ -92,7 +92,7 @@
 
 <div class="form-group">
     <?php
-    $inscripcion_estados = array('CONFIRMADA'=>'CONFIRMADA','NO CONFIRMADA'=>'NO CONFIRMADA','BAJA'=>'BAJA','EGRESO'=>'EGRESO');
+    $inscripcion_estados = array('CONFIRMADA'=>'CONFIRMADA','NO CONFIRMADA'=>'NO CONFIRMADA','BAJA'=>'BAJA','EGRESO'=>'EGRESO','ANULADA'=>'ANULADA');
     echo $this->Form->input('estado_inscripcion', array('label' => false, 'empty' => 'Ingrese un estado de la inscripción...', 'options' => $inscripcion_estados, 'default'=>$defaultForm['estado_inscripcion'],'class' => 'form-control', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'title' => 'Seleccione una opción'));
     ?>
 </div>

--- a/View/Elements/formsSearch/formSearch_inscripcion.ctp
+++ b/View/Elements/formsSearch/formSearch_inscripcion.ctp
@@ -18,7 +18,7 @@
 </div>
 <div class="form-group">
     <?php
-    $inscripcion_estados = array('CONFIRMADA'=>'CONFIRMADA','NO CONFIRMADA'=>'NO CONFIRMADA','BAJA'=>'BAJA','EGRESO'=>'EGRESO');
+    $inscripcion_estados = array('CONFIRMADA'=>'CONFIRMADA','NO CONFIRMADA'=>'NO CONFIRMADA','BAJA'=>'BAJA','EGRESO'=>'EGRESO','ANULADA'=>'ANULADA');
     echo $this->Form->input('estado_inscripcion', array('label' => false, 'empty' => 'Ingrese un estado de la inscripción...', 'options' => $inscripcion_estados, 'between' => '<br>', 'class' => 'form-control', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'title' => 'Seleccione una opción'));
     ?>
 </div>

--- a/View/Elements/inscripcion.ctp
+++ b/View/Elements/inscripcion.ctp
@@ -19,9 +19,17 @@
 	    <hr />
         <div class="text-right">
             <span class="link"><?php echo $this->Html->link('<i class="glyphicon glyphicon-eye-open"></i>', array('controller' => 'inscripcions', 'action' => 'view', $inscripcion['Inscripcion']['id']), array('class' => 'btn btn-success','escape' => false)); ?></span>
+          <!-- No se editan inscripciones con estado ANULADA. -->  
+          <?php if ($inscripcion['Inscripcion']['estado_inscripcion'] != 'ANULADA') : ?>
             <span class="link"><?php echo $this->Html->link('<i class= "glyphicon glyphicon-edit"></i>', array('controller' => 'inscripcions', 'action' => 'edit', $inscripcion['Inscripcion']['id']), array('class' => 'btn btn-warning','escape' => false)); ?></span>
-          <?php if($current_user['role'] == 'superadmin' && $current_user['puesto'] == 'Sistemas'): ?>  
-            <span class="link"><?php echo $this->Html->link('<i class= "glyphicon glyphicon-trash"></i>', array('controller' => 'inscripcions', 'action' => 'delete', $inscripcion['Inscripcion']['id']), array('confirm' => 'Está seguro de borrar la inscripción nro.'.$inscripcion['Inscripcion']['id'], 'class' => 'btn btn-danger','escape' => false)); ?></span>
+          <?php endif; ?>
+          <!-- Sólo para inscripciones del 2020 y para ciertos usuarios. -->
+          <?php if(($inscripcion['Inscripcion']['ciclo_id'] == 7) && ($current_user['role'] == 'usuario' || $current_user['id'] == 1 || $current_user['id'] == 438 || $current_user['id'] == 326 || $current_user['id'] == 325 || $current_user['id'] == 338 || $current_user['id'] == 582)): ?>  
+            <?php if ($inscripcion['Inscripcion']['estado_inscripcion'] != 'ANULADA') { ?>
+              <span class="link"><?php echo $this->Html->link('<i class= "glyphicon glyphicon-trash"></i>', array('controller' => 'inscripcions', 'action' => 'delete', $inscripcion['Inscripcion']['id']), array('confirm' => 'Está seguro de ANULAR la inscripción con legajo nro: '.$inscripcion['Inscripcion']['legajo_nro'], 'class' => 'btn btn-danger','escape' => false)); ?></span>
+                <?php } else { ?>
+                <span class="link"><?php echo $this->Html->link('<i class="glyphicon glyphicon-ban-circle"></i>', array(), array('class' => 'btn btn-danger', 'escape' => false)); ?></span>
+            <?php } ?>
           <?php endif; ?>   
 		</div>
 	</div>

--- a/View/Inscripcions/view.ctp
+++ b/View/Inscripcions/view.ctp
@@ -15,16 +15,22 @@
                         <?php echo($this->Html->link($inscripcion['centro']['sigla'], array('controller' => 'centros', 'action' => 'view', $inscripcion['centro_id']))); ?></p>
                         <b><?php echo __('Alumno:'); ?></b>
                         <?php echo ($this->Html->link("{$inscripcion['alumno']['persona']['nombres']} {$inscripcion['alumno']['persona']['apellidos']}", array('controller' => 'alumnos', 'action' => 'view', $inscripcion['alumno_id']))); ?></p>
-                        <b><?php echo __('Tipo de inscripción:'); ?></b>
+                        <b><?php echo __('| Inscripción - Características:'); ?></b></p>
+                        <b><?php echo __('| Tipo:'); ?></b>
                         <?php echo $inscripcion['tipo_inscripcion']; ?></p>
-                        <b><?php echo __('Estado de la inscripción:'); ?></b>
-                        <?php echo $inscripcion['estado_inscripcion']; ?></p>
-                        <b><?php echo __('Documentación presentada:'); ?></b>
-                        <?php if($inscripcion['estado_documentacion'] == "COMPLETA"){; ?>
-                        <span class="label label-success"><?php echo $inscripcion['estado_documentacion']; ?></span>
-                        <?php } else{; ?>
-                        <span class="label label-danger"><?php echo $inscripcion['estado_documentacion']; ?></span>
+                        <b><?php echo __('| Estado:'); ?></b>
+                        <?php if($inscripcion['estado_inscripcion'] == "ANULADA") {; ?>
+                            <span class="label label-danger"><?php echo $inscripcion['estado_inscripcion']; ?></span></p>
+                        <?php } else if ($inscripcion['estado_inscripcion'] == "CONFIRMADA") {; ?>
+                            <span class="label label-success"><?php echo $inscripcion['estado_inscripcion']; ?></span>
+                        <?php } else if ($inscripcion['estado_inscripcion'] == "NO CONFIRMADA") {?>
+                            <span class="label label-warning"><?php echo $inscripcion['estado_inscripcion']; ?></span>
+                        <?php } else if ($inscripcion['estado_inscripcion'] == "BAJA" || $inscripcion['estado_inscripcion'] == "EGRESO") {?>
+                            <span class="label label-info"><?php echo $inscripcion['estado_inscripcion']; ?></span>
                         <?php } ?></p>
+                        <b><?php echo __('Documentación:'); ?></b>
+                            <span class="opcion"><?php echo $inscripcion['estado_documentacion']; ?></span>
+                        </p>
                         </p>
                     </div>
                     <div class="col-md-4 col-sm-4 col-xs-12">
@@ -162,10 +168,14 @@
                         <div class="opcion"><a href="<?php echo "/gateway/constancia/id:".$inscripcion['id'];?>">Constancia de Inscripción</a></div>
                         <div class="opcion"><a href="<?php echo "/gateway/constancia_regular/id:".$inscripcion['id'];?>">Constancia de Alumno Regular</a></div>
                     <?php //endif; ?>
+                    <?php if ($inscripcion['estado_inscripcion'] != 'ANULADA') : ?>
                     <div class="opcion"><?php echo $this->Html->link(__('Editar'), array('action' => 'edit', $inscripcion['id'])); ?> </div>
+                    <?php endif; ?>
                 <?php endif; ?>  
-                <?php if($current_user['role'] == 'superadmin' && $current_user['puesto'] == 'Sistemas'): ?> 
-                    <div class="opcion"><?php echo $this->Html->link(__('Borrar'), array('action' => 'delete', $inscripcion['id']), null, sprintf(__('Esta seguro de borrar la inscripción %s?'), $inscripcion['id'])); ?></div>
+                <?php if(($inscripcion['ciclo_id'] == 7) && ($current_user['puesto'] == 'Sistemas' || $current_user['id'] == 438 || $current_user['id'] == 326 || $current_user['id'] == 325 || $current_user['id'] == 338 || $current_user['id'] == 582)): ?> 
+                    <?php if ($inscripcion['estado_inscripcion'] != 'ANULADA') { ?>
+                        <div class="opcion"><?php echo $this->Html->link(__('Anular'), array('action' => 'delete', $inscripcion['id']), null, sprintf(__('Esta seguro de ANULAR la inscripción con legajo Nº: %s?'), $inscripcion['legajo_nro'])); ?></div>
+                        <?php } ?>
                 <?php endif; ?>  
               </div>
           </div>


### PR DESCRIPTION

## Descripción
Agrega la posibilidad que usuarios específicos accedan desde el menú ALUMNADO-->INSCRIPCIONES y luego de buscar por legajo una inscripción 2020, pueda ANULARLA (tanto desde el INDEX como desde el VIEW de esa inscripción), dejando registro -en la trayectoria del estudiante- de esa INSCRIPCIÓN con estado "ANULADA" y habilitando al usuario a volver a realizar una nueva INSCRIPCIÓN 2020 en otra institución. En ésta versión no se permite la EDICIÓN de INSCRIPCIONES ANULADAS.
   
## Motivación y Contexto
Ésta funcionalidad resuelve habilitar a los usuarios de las Supervisiones, la ANULACIÓN DE INSCRIPCIONES 2020 y que deben resolver a la brevedad antes de poder realizar una nueva INSCRIPCIÓN 2020 en otra institución.  

## Tipo de cambios
- [ ] Bug fix (cambio que no rompe la api existente y resuelve un issue)
- [x] Nueva funcionalidad (cambio que no rompe la api existente y agrega funcionalidad)
- [ ] Cambio en la api (un fix o funcionalidad que modifica la api existente).